### PR TITLE
Backwards compatible fix for 1.16.4+

### DIFF
--- a/src/main/java/uk/co/thinkofdeath/vanillacord/TypeChecker.java
+++ b/src/main/java/uk/co/thinkofdeath/vanillacord/TypeChecker.java
@@ -21,7 +21,7 @@ public class TypeChecker extends ClassVisitor {
 
             @Override
             public void visitLdcInsn(Object cst) {
-                if (cst instanceof String && ((String) cst).startsWith("multiplayer.disconnect.outdated_server")) {
+                if (cst instanceof String && (((String) cst).startsWith("multiplayer.disconnect.outdated_server") || ((String) cst).startsWith("multiplayer.disconnect.incompatible"))) {
                     handshakeListener = true;
                     hsName = name;
                     hsDesc = desc;


### PR DESCRIPTION
Starting with 1.16.4 the string sent to the player via the handshake is named differently, this fix checks for both variants

### What's Been Changed
The string check for the handshake listener was extended to include both the string up to 1.16.3 and the string used in 1.16.4 and 1.17 snapshots.

### Why It Was Changed
To fix [this crash issue](https://github.com/ME1312/VanillaCord/issues/6) we were experiencing.
