### PR TITLE
Repairing token verification logic

### DIFF
--- a/src/main/java/uk/co/thinkofdeath/vanillacord/helper/BungeeHelper.java
+++ b/src/main/java/uk/co/thinkofdeath/vanillacord/helper/BungeeHelper.java
@@ -51,7 +51,8 @@ public class BungeeHelper {
                     boolean found = false;
                     for (Property property : properties) {
                         if (property.getName().equals("bungeeguard-token")) {
-                            if (!(found = !found) || Arrays.binarySearch(seecret, property.getValue()) < 0) {
+                            if (found || Arrays.binarySearch(seecret, property.getValue()) >= 0) {
+                                found = true;
                                 break;
                             }
                         } else if (i < modified.length) {


### PR DESCRIPTION
Fixing little bug in #18. Before, it didn't "refuse" an invalid token, so the BungeeGuard implementation would be useless.